### PR TITLE
Burtons/optimizations - add declerations

### DIFF
--- a/cl-aa.asd
+++ b/cl-aa.asd
@@ -11,7 +11,7 @@
 
 (defsystem #:cl-aa
   :description "cl-aa: polygon rasterizer"
-  :version "$VERSION$"
+  :version "1"
   :author "Frederic Jolliton <frederic@jolliton.com>"
   :licence "MIT"
   :components ((:file "aa")


### PR DESCRIPTION
Add fixnum and other declerations to give a pretty good increase in rendering performance.  These changes, combinined with my other patch to vecto gave a 50% increase in rendering performance on my tests with no change in image quality or rendering output.
