### PR TITLE
pack.sh, *.asd: change commented-out :version lines, comment them out

### DIFF
--- a/cl-aa-misc.asd
+++ b/cl-aa-misc.asd
@@ -11,7 +11,7 @@
 
 (defsystem #:cl-aa-misc
   :description "cl-aa-misc: some tools related to cl-aa"
-  :version "$VERSION$"
+  ;; :version "$VERSION$"
   :author "Frederic Jolliton <frederic@jolliton.com>"
   :licence "MIT"
   :components ((:file "aa-misc")))

--- a/cl-aa.asd
+++ b/cl-aa.asd
@@ -11,7 +11,7 @@
 
 (defsystem #:cl-aa
   :description "cl-aa: polygon rasterizer"
-  :version "$VERSION$"
+  ;; :VERSION "$VERSION$"
   :author "Frederic Jolliton <frederic@jolliton.com>"
   :licence "MIT"
   :components ((:file "aa")

--- a/cl-paths-ttf.asd
+++ b/cl-paths-ttf.asd
@@ -11,7 +11,7 @@
 
 (defsystem #:cl-paths-ttf
   :description "cl-paths-ttf: vectorial paths manipulation"
-  :version "$VERSION$"
+  ;; :version "$VERSION$"
   :author "Frederic Jolliton <frederic@jolliton.com>"
   :licence "MIT"
   :depends-on ("cl-paths" "zpb-ttf")

--- a/cl-paths.asd
+++ b/cl-paths.asd
@@ -11,7 +11,7 @@
 
 (defsystem #:cl-paths
   :description "cl-paths: vectorial paths manipulation"
-  :version "$VERSION$"
+  ;; :version "$VERSION$"
   :author "Frederic Jolliton <frederic@jolliton.com>"
   :licence "MIT"
   :components ((:file "paths-package")

--- a/cl-vectors.asd
+++ b/cl-vectors.asd
@@ -11,7 +11,7 @@
 
 (defsystem #:cl-vectors
   :description "cl-paths: vectorial paths manipulation"
-  :version "$VERSION$"
+  ;; :version "$VERSION$"
   :author "Frederic Jolliton <frederic@jolliton.com>"
   :licence "MIT"
   :depends-on ("cl-aa" "cl-paths")

--- a/pack.sh
+++ b/pack.sh
@@ -10,5 +10,5 @@ if [ -e "$TARGZ" ]; then
 fi
 mkdir -p "$TARGET" && rm -rf "$TARGET" && mkdir "$TARGET"
 cat MANIFEST|while read FN; do cp "$FN" "$TARGET/$FN"; done
-(cd "$TARGET"; sed -i 's/\$VERSION\$/'"$VERSION"'/' *.asd)
+(cd "$TARGET"; sed -ri 's/;+[ \t]*:[vV][eE][rR][sS][iI][oO][nN][ \t]*\"(\$VERSION)\$\"[ \t]*$/:version '\"$VERSION\"'/' *.asd)
 tar cvzfC "$TARGZ" "$TARGET/.." "$FULLNAME"


### PR DESCRIPTION
This addresses the issue

https://github.com/fjolliton/cl-vectors/issues/2

Commit log:

pack.sh: previously, pack.sh would change a line like

  :version "$VERSION"

to

  :version "0.1.5"

(or whatever the version actually is). Now, it looks for a
commented-out line of the same code, and does the same substitution
while uncommenting the code.

This lets you keep the line with "$VERSION$", which is not a valid
version, commented out, while not running afoul of introspection tools
(e.g., uiop/utility:parse-version).

*.asd: comment out :version lines to work with this new pack.sh
